### PR TITLE
Add build script and .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   - LANG=en_US.UTF-8
   matrix:
   - COMMAND="test-iOS"
-  - COMMAND="test-swift"
+  - COMMAND="test-native"
 script:
 - set -o pipefail
 - xcodebuild -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: objective-c
+osx_image: xcode9.1
+env:
+  global:
+  - LC_CTYPE=en_US.UTF-8
+  - LANG=en_US.UTF-8
+  matrix:
+  - COMMAND="test-iOS"
+  - COMMAND="test-swift"
+script:
+- set -o pipefail
+- xcodebuild -version
+- xcodebuild -showsdks
+- swift -version
+- sh build.sh "$COMMAND"

--- a/build.sh
+++ b/build.sh
@@ -65,7 +65,7 @@ case "$COMMAND" in
     exit 0;
   ;;
 
-  "test-swift")
+  "test-native")
     swift package clean
     swift build
     swift test

--- a/build.sh
+++ b/build.sh
@@ -22,7 +22,7 @@ Usage: sh $0 command
   [Testing]
 
   test-iOS      Run tests on iOS host
-  test-swift	Run tests using `swift test`
+  test-native	Run tests using `swift test`
 EOF
 }
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+
+set -o errexit
+set -o errtrace
+set -o pipefail
+
+PROJECT="Lift.xcodeproj"
+SCHEME="Lift"
+
+IOS_SDK="iphonesimulator11.1"
+IOS_DESTINATION="OS=11.1,name=iPhone 8"
+
+usage() {
+cat << EOF
+Usage: sh $0 command
+  [Building]
+
+  iOS           Build iOS framework
+  native		Build using `swift build`
+  clean         Clean up all un-neccesary files
+
+  [Testing]
+
+  test-iOS      Run tests on iOS host
+  test-swift	Run tests using `swift test`
+EOF
+}
+
+COMMAND="$1"
+
+case "$COMMAND" in
+  "clean")
+    find . -type d -name build -exec rm -r "{}" +\;
+    exit 0;
+  ;;
+
+   "iOS" | "ios")
+    xcodebuild clean \
+    -project $PROJECT \
+    -scheme "${SCHEME}" \
+    -sdk "${IOS_SDK}" \
+    -destination "${IOS_DESTINATION}" \
+    -configuration Debug ONLY_ACTIVE_ARCH=YES \
+    CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO \
+    build | xcpretty -c
+    exit 0;
+  ;;
+
+  "native" | "")
+    swift build
+    exit 0;
+  ;;
+
+   "test-iOS" | "test-ios")
+    xcodebuild clean \
+    -project $PROJECT \
+    -scheme "${SCHEME}" \
+    -sdk "${IOS_SDK}" \
+    -destination "${IOS_DESTINATION}" \
+    -configuration Release \
+    ONLY_ACTIVE_ARCH=YES \
+    CODE_SIGNING_REQUIRED=NO \
+    ENABLE_TESTABILITY=YES \
+    build test | xcpretty -c
+    exit 0;
+  ;;
+
+  "test-swift")
+    swift package clean
+    swift build
+    swift test
+    exit 0;
+  ;;
+esac
+
+usage


### PR DESCRIPTION
This PR adds support for Travis CI. 

### Usage

Build script can be used for building and testing the framework. For example,  you can build iOS framework by running:

```bash
$ sh build.sh iOS
```

You can also initiate testing by running:

```bash
$ sh build.sh test-iOS
```

This script will then be executed by Travis CI when testing pull requests or merging to `master`.