### PR TITLE
Update Swift PackageDescription to v4 manifest format

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,21 @@
+// swift-tools-version:4.0
+
 import PackageDescription
 
 let package = Package(
-    name: "Lift"
+    name: "Lift",
+    products: [
+        .library(
+            name: "Lift",
+            targets: ["Lift"]),
+    ],
+    targets: [
+        .target(
+            name: "Lift",
+            dependencies: [],
+            path: "Lift"),
+        .testTarget(
+            name: "LiftTests",
+            dependencies: ["Lift"]),
+    ]
 )


### PR DESCRIPTION
In accordance to [PackageDescriptionV4](https://github.com/apple/swift-package-manager/blob/master/Documentation/PackageDescriptionV4.md) format.