### PR TITLE
Make description of LiftError more useful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 3.0.0
+# 2.1.0
 
 - Made the `description` of `LiftError` more useful by adding the `message` field.  
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.0.0
+
+- Made the `description` of `LiftError` more useful by adding the `message` field.  
+
+
 # 2.0.2
 
 - Linting

--- a/Lift.podspec
+++ b/Lift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Lift"
-  s.version      = "3.0.0"
+  s.version      = "2.1.0"
   s.summary      = "Working with JSON-like structures"
   s.description  = <<-DESC
                    Lift is a Swift library for generating and extracting values into and out of JSON-like structures.

--- a/Lift.podspec
+++ b/Lift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Lift"
-  s.version      = "2.0.2"
+  s.version      = "3.0.0"
   s.summary      = "Working with JSON-like structures"
   s.description  = <<-DESC
                    Lift is a Swift library for generating and extracting values into and out of JSON-like structures.

--- a/Lift/Info.plist
+++ b/Lift/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0</string>
+	<string>2.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Lift/Info.plist
+++ b/Lift/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.2</string>
+	<string>3.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Lift/LiftError.swift
+++ b/Lift/LiftError.swift
@@ -10,8 +10,8 @@ import Foundation
 
 /// `LiftError` holds besides a description of the Error the `key` (or path) to where the error occured.
 public struct LiftError: Error, CustomStringConvertible {
-    /// The description of the error
-    public let description: String
+    /// The error message
+    public let message: String
 
     /// The key (path) to where the error occured. Helpful for debugging.
     public let key: String
@@ -19,6 +19,11 @@ public struct LiftError: Error, CustomStringConvertible {
     /// The context jar. Helpful for debugging.
     public var context: String { return _context() }
     fileprivate let _context: () -> String
+
+    /// The description of the error
+    public var description: String {
+        return "LiftError(message: '\(message)', key: '\(key)')"
+    }
 }
 
 public extension LiftError {
@@ -31,7 +36,7 @@ public extension LiftError {
 extension LiftError: CustomNSError {
     public static var errorDomain: String { return "com.izettle.lift" }
     public var errorUserInfo: [String: Any] {
-        return [NSLocalizedDescriptionKey: "LiftError(description: \(description), key: \(key), context: \(context))"]
+        return [NSLocalizedDescriptionKey: description]
     }
 }
 
@@ -74,17 +79,17 @@ extension Optional {
 extension LiftError {
     init(error: LiftError, key: String, context jar: Jar) {
         self.key = key.isEmpty ? error.key : key + ((error.key.isEmpty || error.key.hasPrefix("[")) ? error.key : ( "." + error.key))
-        description = error.description
+        self.message = error.message
         _context = { error.context.isEmpty ? jar.contextDescription : error.context }
     }
 
-    init(_ description: String, key: String, context: @escaping () -> String) {
+    init(_ message: String, key: String, context: @escaping () -> String) {
         self.key = key
-        self.description = description
+        self.message = message
         _context = context
     }
 
-    init(_ description: String, key: String? = nil, context jar: Jar) {
-        self.init(description, key: key ?? jar.key(), context: { jar.contextDescription })
+    init(_ message: String, key: String? = nil, context jar: Jar) {
+        self.init(message, key: key ?? jar.key(), context: { jar.contextDescription })
     }
 }

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Check the [Usage](#usage) section for more information and examples.
 #### [Carthage](https://github.com/Carthage/Carthage)
 
 ```shell
-github "iZettle/Lift" >= 2.0
+github "iZettle/Lift" >= 3.0
 ```
 
 #### [Cocoa Pods](https://github.com/CocoaPods/CocoaPods)
@@ -114,7 +114,7 @@ platform :ios, '9.0'
 use_frameworks!
 
 target 'Your App Target' do
-  pod 'Lift', '~> 2.0'
+  pod 'Lift', '~> 3.0'
 end
 ```
 
@@ -127,7 +127,7 @@ let package = Package(
   name: "Your Package Name",
   dependencies: [
       .Package(url: "https://github.com/iZettle/Lift.git",
-               majorVersion: 2)
+               majorVersion: 3)
   ]
 )
 ```

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Check the [Usage](#usage) section for more information and examples.
 #### [Carthage](https://github.com/Carthage/Carthage)
 
 ```shell
-github "iZettle/Lift" >= 3.0
+github "iZettle/Lift" >= 2.0
 ```
 
 #### [Cocoa Pods](https://github.com/CocoaPods/CocoaPods)
@@ -114,7 +114,7 @@ platform :ios, '9.0'
 use_frameworks!
 
 target 'Your App Target' do
-  pod 'Lift', '~> 3.0'
+  pod 'Lift', '~> 2.0'
 end
 ```
 
@@ -127,7 +127,7 @@ let package = Package(
   name: "Your Package Name",
   dependencies: [
       .Package(url: "https://github.com/iZettle/Lift.git",
-               majorVersion: 3)
+               majorVersion: 2)
   ]
 )
 ```

--- a/README.md
+++ b/README.md
@@ -546,7 +546,7 @@ Because JSON is typically nested, it is useful to extend errors with some positi
 
 ```swift
 struct LiftError: Error {
-  let description: String
+  let message: String
   let key: String
   let context: String
 }

--- a/Tests/Info.plist
+++ b/Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0</string>
+	<string>2.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/Tests/Info.plist
+++ b/Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.2</string>
+	<string>3.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
This PR separates the concepts of `message` and `description` in `LiftError` (currently `description`  seems to be used for both). The goal is to make crash reports more useful by turning this:
```
Fatal error: 'try!' expression unexpectedly raised an error: Value missing: file <...>
```
into this:
```
Fatal error: 'try!' expression unexpectedly raised an error: LiftError(message: 'Value missing', key: 'uuid_'): file <...>
```