### PR TITLE
Fix compilation error in swift 5.1

### DIFF
--- a/Lift/Jar+Object.swift
+++ b/Lift/Jar+Object.swift
@@ -9,11 +9,6 @@
 import Foundation
 
 extension Jar {
-    init(object: Object, context: Context = [], key: @escaping () -> String = { "" }) {
-        self.object = object
-        self.context = context
-        self.key = key
-    }
 
     /// Internal representation to avoid repetitive value conversions as well as handling error and absent states
     enum Object {

--- a/Lift/Jar.swift
+++ b/Lift/Jar.swift
@@ -18,8 +18,17 @@ import Foundation
 /// For a value to be liftable it must conform to `Liftable` or `JarConvertible`
 public struct Jar {
     internal var object: Object
-    internal var key: () -> String = { "" } // Capturing of the current key used for lazy evaluation (to avoid a peformance hit for happy cases)
     public var context: Context = []
+    internal var key: () -> String = { "" } // Capturing of the current key used for lazy evaluation (to avoid a peformance hit for happy cases)
+
+    // Use auto-generated initializer in swift 5.1
+    #if swift(<5.1)
+    internal init(object: Object, context: Context = [], key: @escaping () -> String = { "" }) {
+        self.object = object
+        self.context = context
+        self.key = key
+    }
+    #endif
 }
 
 public extension Jar {

--- a/Tests/LiftTests/JarTests.swift
+++ b/Tests/LiftTests/JarTests.swift
@@ -97,7 +97,7 @@ class JarTests: XCTestCase {
     }
 
     func testJarToJar() throws {
-        var jar: Jar = ["val1": 1, "val2": 2]
+        let jar: Jar = ["val1": 1, "val2": 2]
         let jar1: Jar = jar["val1"]
         let jar2: Jar = try jar["val1"]^
         XCTAssertEqual(try jar1^, 1)


### PR DESCRIPTION
Swift 5.1 auto-generates the initializer for `Jar`. This change is backwards compatible.