### PR TITLE
Replaced iZettle strings with PayPal equivalents

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-present, iZettle AB
+Copyright (c) 2016-present, PayPal Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/Lift.podspec
+++ b/Lift.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
                    DESC
   s.homepage     = "https://github.com/iZettle/Lift"
   s.license      = { type: "MIT", file: "LICENSE.md" }
-  s.author       = { 'iZettle AB' => 'hello@izettle.com' }
+  s.author       = { 'PayPal Inc.' => 'hello@izettle.com' }
 
   s.osx.deployment_target = "10.9"
   s.ios.deployment_target = "9.0"

--- a/Lift.xcodeproj/project.pbxproj
+++ b/Lift.xcodeproj/project.pbxproj
@@ -194,7 +194,7 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0820;
 				LastUpgradeCheck = 1020;
-				ORGANIZATIONNAME = iZettle;
+				ORGANIZATIONNAME = "PayPal Inc.";
 				TargetAttributes = {
 					21E1D39E1D9410F000A91CA0 = {
 						CreatedOnToolsVersion = 8.0;

--- a/Lift/Jar+Additions.swift
+++ b/Lift/Jar+Additions.swift
@@ -3,7 +3,7 @@
 //  Lift
 //
 //  Created by Måns Bernhardt on 2016-05-23.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import Foundation

--- a/Lift/Jar+Array.swift
+++ b/Lift/Jar+Array.swift
@@ -3,7 +3,7 @@
 //  Lift
 //
 //  Created by Måns Bernhardt on 2017-04-03.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import Foundation

--- a/Lift/Jar+Context.swift
+++ b/Lift/Jar+Context.swift
@@ -3,7 +3,7 @@
 //  Lift
 //
 //  Created by Måns Bernhardt on 2017-04-03.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import Foundation

--- a/Lift/Jar+Dictionary.swift
+++ b/Lift/Jar+Dictionary.swift
@@ -3,7 +3,7 @@
 //  Lift
 //
 //  Created by Måns Bernhardt on 2017-04-03.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import Foundation

--- a/Lift/Jar+Expressible.swift
+++ b/Lift/Jar+Expressible.swift
@@ -3,7 +3,7 @@
 //  Lift
 //
 //  Created by Måns Bernhardt on 2016-05-23.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import Foundation

--- a/Lift/Jar+Object.swift
+++ b/Lift/Jar+Object.swift
@@ -3,7 +3,7 @@
 //  Lift
 //
 //  Created by Måns Bernhardt on 2016-05-23.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import Foundation

--- a/Lift/Jar.swift
+++ b/Lift/Jar.swift
@@ -3,7 +3,7 @@
 //  Lift
 //
 //  Created by Måns Bernhardt on 2016-05-23.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import Foundation

--- a/Lift/JarElement+Primitives.swift
+++ b/Lift/JarElement+Primitives.swift
@@ -3,7 +3,7 @@
 //  Lift
 //
 //  Created by Måns Bernhardt on 2016-05-23.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import Foundation

--- a/Lift/JarElement.swift
+++ b/Lift/JarElement.swift
@@ -3,7 +3,7 @@
 //  Lift
 //
 //  Created by Måns Bernhardt on 2016-05-23.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import Foundation

--- a/Lift/LiftError.swift
+++ b/Lift/LiftError.swift
@@ -3,7 +3,7 @@
 //  Lift
 //
 //  Created by Måns Bernhardt on 2017-04-03.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import Foundation

--- a/Lift/ValueForKey.swift
+++ b/Lift/ValueForKey.swift
@@ -3,7 +3,7 @@
 //  Lift
 //
 //  Created by Måns Bernhardt on 2016-05-23.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import Foundation

--- a/Tests/LiftTests/IntegerTests.swift
+++ b/Tests/LiftTests/IntegerTests.swift
@@ -3,7 +3,7 @@
 //  Lift
 //
 //  Created by Mattias Jähnke on 2017-05-10.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import XCTest

--- a/Tests/LiftTests/JarTests.swift
+++ b/Tests/LiftTests/JarTests.swift
@@ -3,7 +3,7 @@
 //  JarTests
 //
 //  Created by Måns Bernhardt on 2016-05-23.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import XCTest


### PR DESCRIPTION
### What has been done?
Replaced iZettle strings with PayPal equivalents

<!--- This can be a link to task or more detailed explaination --> 
### Why was it done?
The PayPal takeover and legal compliance