### PR TITLE
Decodable compatibility update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.4.1
+# 2.5.1
 - Make vals dictionary retrievable from Jar.Context so it can be used in compatibility code with other encoding systems like Codable. 
 
 # 2.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.4.1
+- Make vals dictionary retrievable from Jar.Context so it can be used in compatibility code with other encoding systems like Codable. 
+
 # 2.4.0
 
 - Xcode 13.0 compatibility

--- a/Lift.xcodeproj/project.pbxproj
+++ b/Lift.xcodeproj/project.pbxproj
@@ -420,7 +420,7 @@
 				INFOPLIST_FILE = Lift/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @loader_path/../Frameworks @executable_path/../Frameworks";
-				MARKETING_VERSION = 2.4.0;
+				MARKETING_VERSION = 2.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iZettle.Lift;
 				PRODUCT_NAME = Lift;
 				SKIP_INSTALL = YES;
@@ -441,7 +441,7 @@
 				INFOPLIST_FILE = Lift/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @loader_path/../Frameworks @executable_path/../Frameworks";
-				MARKETING_VERSION = 2.4.0;
+				MARKETING_VERSION = 2.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iZettle.Lift;
 				PRODUCT_NAME = Lift;
 				SKIP_INSTALL = YES;

--- a/Lift.xcodeproj/project.pbxproj
+++ b/Lift.xcodeproj/project.pbxproj
@@ -420,7 +420,7 @@
 				INFOPLIST_FILE = Lift/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @loader_path/../Frameworks @executable_path/../Frameworks";
-				MARKETING_VERSION = 2.4.1;
+				MARKETING_VERSION = 2.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iZettle.Lift;
 				PRODUCT_NAME = Lift;
 				SKIP_INSTALL = YES;
@@ -441,7 +441,7 @@
 				INFOPLIST_FILE = Lift/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @loader_path/../Frameworks @executable_path/../Frameworks";
-				MARKETING_VERSION = 2.4.1;
+				MARKETING_VERSION = 2.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iZettle.Lift;
 				PRODUCT_NAME = Lift;
 				SKIP_INSTALL = YES;

--- a/Lift/Jar+Context.swift
+++ b/Lift/Jar+Context.swift
@@ -36,6 +36,8 @@ public extension Jar {
         public init(_ vals: JarContextValue?...) {
             self.init(vals)
         }
+
+        public func getVals() -> [String: Any] { vals }
     }
 
     /// Creates a union between `self` context and `val`, where `val` context values will be replacing the same context value's in `self`'s context if they already exists


### PR DESCRIPTION
Expose a method that allows to get the current state of the `Jar` `Context`. This is crucial to write compatibility code with Codable.